### PR TITLE
ワークフローが手動実行できるように設定変更

### DIFF
--- a/.github/workflows/deploy-cloudfunctions.yml
+++ b/.github/workflows/deploy-cloudfunctions.yml
@@ -1,6 +1,7 @@
 name: Deploy Cloud Functions
 on:
-  # プルリククローズ時にに実行
+  # 手動orプルリククローズ時にに実行
+  workflow_dispatch:
   pull_request:
     types:
       - closed

--- a/.github/workflows/deploy-cloudfunctions.yml
+++ b/.github/workflows/deploy-cloudfunctions.yml
@@ -54,7 +54,3 @@ jobs:
         --trigger-http
         --no-allow-unauthenticated
         --run-service-account gha-cloudfunctions-deploy@${{ vars.PROJECT_ID }}.iam.gserviceaccount.com
-
-    # Example of using the output
-    - id: 'test'
-      run: 'curl "${{ steps.deploy.outputs.url }}"'


### PR DESCRIPTION
デフォルトブランチであるmainブランチに手動実行設定がないとGUI上から手動実行できないため、ワークフロー手動実行の設定を追加します。